### PR TITLE
Fix color not appearing over image when hovering

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,30 +1,30 @@
 :root {
   --independence-max-width: 1440px;
-  --art-color: rgba(142, 202, 230, 1.0);
-  --diaspora-color: rgba(33, 158, 188, 1.0);
-  --politics-color: rgba(2, 48, 71, 1.0);
-  --science-color: rgba(45, 106, 79, 1.0);
-  --sports-color: rgba(27, 67, 50, 1.0);
+  --art-color: 142, 202, 230;
+  --diaspora-color: 33, 158, 188;
+  --politics-color: 2, 48, 71;
+  --science-color: 45, 106, 79;
+  --sports-color: 27, 67, 50;
 }
 
 .art {
-  color: var(--art-color);
+  color: rgb(var(--art-color));
 }
 
 .diaspora {
-  color: var(--diaspora-color);
+  color: rgb(var(--diaspora-color));
 }
 
 .politics {
-  color: var(--politics-color);
+  color: rgb(var(--politics-color));
 }
 
 .science {
-  color: var(--science-color);
+  color: rgb(var(--science-color));
 }
 
 .sports {
-  color: var(--sports-color);
+  color: rgb(var(--sports-color));
 }
 
 .App {


### PR DESCRIPTION
#2 did not wrap the css variables in an `rgb()` call which prevented those variables' color values from being parsed correctly. This PR fixes this.