### PR TITLE
Add functionality to display images in a carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-markdown": "^9.0.1",
         "react-scripts": "5.0.1",
         "rehype-raw": "^7.0.0",
+        "swiper": "^11.0.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -18096,6 +18097,24 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.5.tgz",
+      "integrity": "sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-markdown": "^9.0.1",
     "react-scripts": "5.0.1",
     "rehype-raw": "^7.0.0",
+    "swiper": "^11.0.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/essays/5Pd4YEOHgXbBFWD6bqSx.md
+++ b/public/essays/5Pd4YEOHgXbBFWD6bqSx.md
@@ -1,7 +1,12 @@
 Between the primary and secondary art markets, the general representations of what African art is exist at near opposite ends of the spectrum. The primary market involves the selling and buying of work that has never been sold and, more importantly, valued before. This is the artwork that comes straight from the artist’s studio and into the hands of dealers, collectors, galleries, and art fairs. This becomes the milieu of contemporary art we see today. The secondary market, in contrast to the primary market, involves the re-selling of work that has already been evaluated. This is the kind of work seen in museums and the collections of collectors. At the mercy of tastes and trends, it is not surprising that what became emblematic of African art is different. Within museums, the more public institutions compared to galleries and art fairs, African art is rooted in history and the past. Ceremonial and utilitarian masks, clothing, sculptures, and objects are tied to locations and tribes rather than a single artist. Whereas, within the contemporary art market, identity and the creation of it is important. Each work is attributed to a single artist, their practice, and the life experiences that have contributed to it. The membrane that exists between the two markets has only been permeable for contemporary African artists for the past few years with introductions of artists such as ABOUDIA, the Ivorian-born and Brooklyn-based mixed-media painter, and Julie Mehretu, the American-Ethiopian large-scale abstractionist, into the auction and museum worlds. For others who have yet to garner the same following and attention, galleries and the accompanying art fairs are their only means of exposure to the wider art market.
 
-![](/images/articles/contemporary_artists_1.png)
-<em>Aboudia, _Enfants dans la Rue 3_, 2013, Courtesy of Saatchi Gallery</em>
+<div class="image-carousel">
+/images/articles/contemporary_artists_1.png
+#cap#Aboudia, _Enfants dans la Rue 3_, 2013, Courtesy of Saatchi Gallery
+/images/articles/contemporary_artists_2.png
+#cap#Julie Mehretu, Hineni (E. 3:4), 2018, Courtesy of the Whitney Museum of American Art, Photograph by Tom Powel Imaging
+</div>
+
 <br />
 <br />
 
@@ -14,37 +19,158 @@ Between the primary and secondary art markets, the general representations of wh
 
 An admittedly selfish first choice, Salah Elmur (or El Mur, depending on who you ask) is a Sudanese painter, graphic designer, author, and filmmaker living and working in Cairo. The first time I saw his work was at the Chicago EXPO, presented as a part of Cape Town-based gallery, Martin Projects. Elmur’s work is imbued with a sense of nostalgia as he captures aspects of Sudanese life in his paintings with a surrealist flair, defying rules of proportion and arrangement. The Chicago EXPO which is a ticketed, open to the public event hosted every year in Chicgao’s Navy Pier, is an excellent way of being exposed to a variety of galleries, museums, art collectives in Chicago, and more. Elmur has been collected at the Centre Pompidou in Paris, the Museum of African Contemporary Art Al Maaden in Marrakesh, and the Zeitz Museum of Contemporary Art Africa in Cape Town.
 
+<div class="image-carousel">
+/images/articles/contemporary_artists_3.png
+#cap#Salah Elmur, Red Rocks Land, 2022, Courtesy of Gallery 1957
+/images/articles/contemporary_artists_4.png
+#cap#Salah Elmur, Liberty Fountain, 2021-2022, Courtesy of Vigo Gallery
+/images/articles/contemporary_artists_5.png
+#cap#Salah Elmur, Rain and Thunder Day, 2022, Courtesy of Vigo Gallery
+</div>
+
+<br />
+<br />
+
 ## Abdoulaye Konaté
 
 Abdoulaye Konaté is a Malian artist primarily known for his work with traditional Malian textiles, creating colorful installations that comment on the traditions of West African craftsmanship. Though I was familiar with him because of my own personal studies at the Univeristy, the first time I got to see his work in person was at the 1-54 art festival held in Marrakesh. It was only in person that I could realize the scale of his work. The use of cloth in his practices bridges the divide between the contemporary and the historical while its volumes allow him to broach the realm of abstraction. His work features commentary about the economic, social, and political problems in Africa. The 1-54 is an art festival held around the world in Marrakesh, New York, and London with the dedicated aim of heightening the visibility of Contemporary African art. His work has been collected by the Metropolitan Museum of Art in New York and the Centre Pompidou in Paris.
+
+<div class="image-carousel">
+/images/articles/contemporary_artists_6.png
+#cap#Abdoulaye Konaté, Composition 5, 2012, Courtesy of Revue Noire
+/images/articles/contemporary_artists_7.png
+#cap#Abdoulaye Konaté, Croiz de Lumière, 2012, Courtesy of Revue Noire
+/images/articles/contemporary_artists_8.png
+#cap#Abdoulaye Konaté, Composition en Jaune, 2018, Courtesy of Sean Kelly, New York
+</div>
+
+<br />
+<br />
 
 ## Fathi Hassan
 
 Another 1-54 discovery, Fathi Hassan is an Egyptian-born, Scotland-based artist whose work primarily incorporates Arabic script into his installations. Of Nubian and Egyptian descent, his work is altogether familiar and a reimagining of concepts of forced migration and the loss incurred with colonial domination. The script featured in his works on paper, photographs, or drawings reflects the consequences of cultural dominiation in its illegibility. Taking on different forms, the script takes the shape of flowers, animals, human faces, and more, affording the work a symbolic and literal meaning. His work has been collected by the Victoria and Albert Msuuem and the British Museum in London, the Smithsonian National Museum of African Art in Washington D.C., and the Farjam Collections.
 
+<div class="image-carousel">
+/images/articles/contemporary_artists_9.png
+#cap#Fathi Hassan, Polyphemus Foot, 2020, Courtesy of Sulger-Buel Gallery
+/images/articles/contemporary_artists_10.png
+#cap#Fathi Hassan, Different Sky, 2022, Courtesy of Sulger-Buel Galery
+/images/articles/contemporary_artists_11.png
+#cap#Fathi Hassan, Container, 2012, Courtesy of Sulger-Buel Gallery
+</div>
+
+<br />
+<br />
+
 ## Hako Hankson
 
 Born in Western Cameroon, Hako Hankson, whose real name is Gaston Hako, is a painter whose work recasts the myths of African civilizations. Providing ancient histories a contemporary resonance, Hankson’s work is a method of storytelling that brings otherwise underrepresented themes of African dance, theater, and rites into the conversation. Inspired by his father who was a traditional sculptor and dignitary, Hanson was raised with the understanding of the importance of ceremonial objects in practices. In 2015, he founded the IN and OFF Art Center in Douala, Cameroon, a location for artists of all experience levels and his workshop.
+
+<div class="image-carousel">
+/images/articles/contemporary_artists_12.png
+#cap#Hako Hanson, The mother, 2017, Courtesy of OH Gallery
+/images/articles/contemporary_artists_13.png
+#cap#Hako Hanson, L’usure de l’espirit, 2019, Courtesy of OH Gallery
+/images/articles/contemporary_artists_14.png
+#cap#Hako Hanson, Chemin vers l’inconnu I, 2022, OH Gallery
+</div>
+
+<br />
+<br />
 
 ## Joana Choumali
 
 Part of the running trend of artists whose work I have been lucky to see first-hand, Abidjan-based artist Joana Choumali’s work was also featured in the 1-54 Art Festival. A freelance photographer, Choumali’s recent work explores the diversity of African cultures and diversity through the combination of her photography with religious imagery through the use of mixed media that combines practices of embroidery with her photography. Her work has been exhibited at the Museum of Civilizations and Palais de la Culture in AbidiAbidjaning the Photoquai Biennale at the Musee Quai de Branly in Paris, and the Zeitz Museum of Contemporary African Art in Capetown.
 
+<div class="image-carousel">
+/images/articles/contemporary_artists_15.png
+#cap#Joana Choumali, Untitled, 2018, Courtesy of the artist
+/images/articles/contemporary_artists_16.png
+#cap#Joana Choumali, Unstoppable, 2020, Courtesy of the Artist
+/images/articles/contemporary_artists_17.png
+#cap#Joana Choumali, Self Help, 2019, Courtesy of the Artist
+</div>
+
+<br />
+<br />
+
 ## Zizipho Poswa
 
 Cape Town-based ceramicist, Zizipho Poswa is renowned for her hand-coiled, large-scale works. Bold declarations of African womanhood, the sculptures are allusions to the Xhosa culture she grew up around. Currently featured in The Metropolitan Museum’s Before Yesterday We Could Fly: An Afrofuturist Period Room, Poswa’s work has garnered recognition for its moving references to the cultural practices surrounding Xhosa women such as lobola (bride-wealth) and the hairstyles of Black women in Africa and across the diaspora. Her work has been collected by the Metropolitan Museum of Art in New York, The Los Angeles County Museum of Art, the Philadelphia Museum of Art, THe LOEWE Foundation, and several private collections around the world.
+
+<div class="image-carousel">
+/images/articles/contemporary_artists_18.png
+#cap#Zizipho Poswa, Omulenda, Ovawambo, 2022, Courtesy of Southern Guild
+/images/articles/contemporary_artists_19.png
+#cap#Zizipho Poswa, uMyeni (Groom), 2021, Courtesy of Southern Guild
+/images/articles/contemporary_artists_20.png
+#cap#Zizipho Poswa, Magodi — Mu’Teni (She That Shines Like the Sun), 2021, Courtesy
+</div>
+
+<br />
+<br />
 
 ## Prince Gyasi
 
 Living and working in Ghana, Prince Gyasi produces beautifully vivid photographs depicting the realities of his home country. Part of a wave of younger artists, Gyasi has made a name for himself on social media through Instagram and Twitter, using it as a means for showcasing his photographs. The unique thing about Gyasi’s work is that he takes his photographs on an iPhone, placing his work within an accessible context while the use of deeply stylized digital manipulation ensures his artwork is inherently unique to his practice.
 
+<div class="image-carousel">
+/images/articles/contemporary_artists_21.png
+#cap#Prince Gyasi, Agony of an Orphan, 2018, Courtesy of Maat Gallery
+/images/articles/contemporary_artists_22.png
+#cap#Prince Gyasi, The Power of Choice / The Choice of Power, 2021, Courtesy of Christie’s
+/images/articles/contemporary_artists_23.png
+#cap#Prince Gyasi, The Arrival, 2022, Courtesy of Phillips Auctioneers
+</div>
+
+<br />
+<br />
+
 ## Hyacinthe Ouattara
 
 Multidisciplinary in practice, Burkinabe artist Hyacinthe Ouattara uses color, material, and texture to situate the feelings of his work. His work with textiles has roots in anatomical references whereas his work with plastic touches on themes of balance, memory, representation, and intimacy. Overall, his work is incredibly gestural, guided by spontaneity and the pursuit of sensation. His work has been exhibited worldwide and was included in the 2022 Dakar and Kinshasa Biennales.
 
+<div class="image-carousel">
+/images/articles/contemporary_artists_24.png
+#cap#Hyacinthe Ouattara, Constellation Organique, 2023, Courtesy of 193 Gallery
+/images/articles/contemporary_artists_25.png
+#cap#Hyacinthe Ouattara, Cartographies Humaines 5, 2020
+/images/articles/contemporary_artists_26.png
+#cap#Hyacinthe Ouattara, Le Sacrifice, 2023, Courtesy of 193 Gallery
+</div>
+
+<br />
+<br />
+
 ## Wangechi Mutu
 
 Kenyan-born visual artist, Wangechi Mutu is known for her painting, sculpture, film, and performance work. Now based in New York, Mutu’s work features commentary on race, gender, identity, and art history. In subject matter her works seem to broach the realm of Afrofuturism featuring alien-like figures and distorted faces, tackling topics of the history of those of African descent and how it can be reimagined. Her work was exhibited at the 2019 Whitney Biennale in New York, the High Museum of Art in Atlanta, and the New Museum in New York.
+
+<div class="image-carousel">
+/images/articles/contemporary_artists_27.png
+#cap#Wangechi Mutu, Le Noble Savage, 2006, Courtesy of the artist
+/images/articles/contemporary_artists_28.jpg
+#cap#Wangechi Mutu, Chocolate Nguva, 2015, Courtesy of Carolina Nitsch Gallery
+/images/articles/contemporary_artists_29.png
+#cap#Wangechi Mutu, Howl, 2023, Courtesy of Phillips Auctioneers
+</div>
+
+<br />
+<br />
+
+## Peju Alatise
+
+One of the first Nigerian artists to be exhibited at the Venice Biennale in 2017, Peju Alatise is a multimedia artist incorporating painting, sculpture, mixed media, poetry, and architecture into her practice. Alatise’s work touches on the status of African individuals on a global scale, fueling discourse on the positionality of African peoples and nations within global affairs. More specifically, her work concerns the lives of African girls and women and the webs they are caught in when it comes to religion, politics, and social expectations. Currently, Alatise is a fellow at the National Museum of African Art and has exhibited globally.
+
+<div class="image-carousel">
+/images/articles/contemporary_artists_30.png
+#cap#Peju Alatise, In the Beginning. Eve Should Have Stayed in Bed that Day, 2019, Courtesy of Sulger-Buel Gallery
+/images/articles/contemporary_artists_31.png
+#cap#Peju Alatise, Sim and the Glass Birds, 2022, Courtesy Frieze and Linda Nylind
+/images/articles/contemporary_artists_32.png
+#cap#Peju Alatise, Silifat (Series) IV, 2023, Courtesy of ko
+</div>
 
 <br />
 <br />

--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,8 @@
 }
 
 .page-wrapper {
+  display: grid;
+  justify-content: center;
   width: 100vw;
   max-width: 1440px;
   margin: 0 auto;

--- a/src/pages/Article/assets/Article.css
+++ b/src/pages/Article/assets/Article.css
@@ -9,10 +9,6 @@
   margin-bottom: 20px;
 }
 
-#article-body img {
-  width: 100%;
-}
-
 #article-body a {
   color: black;
 }

--- a/src/pages/Article/assets/ImageCarousel.css
+++ b/src/pages/Article/assets/ImageCarousel.css
@@ -1,0 +1,18 @@
+.image-carousel {
+  position: relative;
+  width: 100%;
+}
+
+.image-carousel img {
+  display: inline-block;
+  object-fit: contain;
+  max-height: 400px;
+  width: 100%;
+  justify-self: center;
+}
+
+.image-carousel .carousel-caption {
+  display: block;
+  font-size: 1.2rem;
+  margin-top: 20px;
+}

--- a/src/pages/Article/components/ImageCarousel.js
+++ b/src/pages/Article/components/ImageCarousel.js
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { EffectFade, Navigation, Pagination } from "swiper/modules";
+import Markdown from "react-markdown";
+
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/effect-fade";
+import "../assets/ImageCarousel.css";
+
+export default function ImageCarousel({ children }) {
+  children = children.split("\n").filter((child) => child !== "");
+
+  const components = {
+    p: "small",
+  };
+
+  // Loop through the children and if the child starts with #cap# then
+  // add it to the previous {img} as {caption}
+  const imageAndCaption = children.reduce((acc, child, index, array) => {
+    if (child.startsWith("#cap#")) {
+      acc[acc.length - 1] = {
+        ...acc[acc.length - 1],
+        caption: child.substring(5),
+      };
+    } else {
+      acc.push({ img: child, caption: null });
+    }
+    return acc;
+  }, []);
+
+  // for (let i = 0; i < children.length; i++) {
+  //   if (children[i].startsWith("#cap#")) {
+  //     imageAndCaption[i - 1] = {
+  //       img: children[i - 1],
+  //       caption: children[i].substring(5),
+  //     };
+  //     imageAndCaption.splice(i, 1);
+  //   } else {
+  //     imageAndCaption.push({ img: children[i], caption: null });
+  //   }
+  // }
+  //
+  console.log(imageAndCaption);
+
+  function renderImageSlide(el) {
+    return (
+      <>
+        <SwiperSlide key={el.img}>
+          <img src={el.img} alt="alt" />
+          <Markdown components={components} className="carousel-caption">
+            {el.caption}
+          </Markdown>
+        </SwiperSlide>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Swiper
+        loop={true}
+        spaceBetween={10}
+        navigation={true}
+        modules={[Navigation, Pagination, EffectFade]}
+        className="image-carousel"
+        effect="fade"
+        fadeEffect={{ crossFade: true }}
+      >
+        {imageAndCaption.map((el) => renderImageSlide(el))}
+      </Swiper>
+    </>
+  );
+}

--- a/src/pages/Article/components/index.js
+++ b/src/pages/Article/components/index.js
@@ -6,7 +6,20 @@ import { collection, where, query, getDocs } from "firebase/firestore";
 import { useParams } from "react-router-dom";
 import Markdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
+import ImageCarousel from "./ImageCarousel";
 import "../assets/Article.css";
+
+const DivRenderer = (props) => {
+  if (props.className === "image-carousel") {
+    return <ImageCarousel {...props} />;
+  } else {
+    return <div {...props} />;
+  }
+};
+
+const components = {
+  div: DivRenderer,
+};
 
 export default function Article() {
   const [article, setArticle] = useState({ data: null, id: null });
@@ -53,15 +66,15 @@ export default function Article() {
     }
   }, [article]);
 
-  console.log(<Markdown>{body}</Markdown>);
-
   if (article.data === null) return <h1>Loading...</h1>;
   return (
     <>
       <TitleImage article={article.data} />
       <div className="page-wrapper">
         <div id="article-body">
-          <Markdown rehypePlugins={[rehypeRaw]}>{body}</Markdown>
+          <Markdown components={components} rehypePlugins={[rehypeRaw]}>
+            {body}
+          </Markdown>
         </div>
         <AuthorBlurb authorName={article.data.author} />
       </div>


### PR DESCRIPTION
# Purpose
This PR implements functionality to display images in a carousel/gallery for use in article pages. Closes #16.

## Implementation Details
The syntax that the markdown uses to display images is crucial. Here is an example:

```html
<div class="image-carousel">
/images/articles/contemporary_artists_3.png
#cap#Salah Elmur, Red Rocks Land, 2022, Courtesy of Gallery 1957
/images/articles/contemporary_artists_4.png
#cap#Salah Elmur, Liberty Fountain, 2021-2022, Courtesy of Vigo Gallery
/images/articles/contemporary_artists_5.png
#cap#Salah Elmur, Rain and Thunder Day, 2022, Courtesy of Vigo Gallery
</div>
```

The `#cap#` prefix is used to denote a caption for the image.
