### PR TITLE
Trim Navbar height

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,8 +15,7 @@
   --sports-medium: 194, 229, 214;
   --sports-light: 232, 252, 242;
   --subheading-bg-color: rgba(140, 140, 140, 1);
-  --nav-bar-height: min(25vw, 110px);
-  --nav-bar-height-thin: 80px;
+  --nav-bar-height: 80px;
   --heading-1-size: 30px;
   --heading-1-size-value: 5.3;
   --heading-2-size: 26px;
@@ -127,6 +126,36 @@
   margin: 0 auto;
   padding: 30px 24px;
 }
+
+/*** NAVBAR STYLES ***/
+.independence-header {
+  justify-self: center;
+  font-size: 2.2rem;
+  font-weight: 400;
+  font-family: Times, Georgia, serif;
+  color: white;
+  text-decoration: none;
+}
+
+.independence-header h4 {
+  font-weight: 200;
+}
+
+@media screen and (max-width: 767px) {
+  p .independence-header {
+    grid-column: 2 / 4;
+    justify-self: start;
+  }
+}
+
+@media screen and (max-width: 425px) {
+  .independence-header * {
+    font-size: 1.5rem;
+    padding-left: 20px;
+  }
+}
+
+/*** END NAVBAR STYLES ***/
 
 @keyframes App-logo-spin {
   from {

--- a/src/assets/NavbarStyles.css
+++ b/src/assets/NavbarStyles.css
@@ -22,11 +22,6 @@
   justify-self: center;
 }
 
-#logo-container img {
-  width: 100%;
-  height: 100%;
-}
-
 #expand-menu {
   display: flex;
   column-gap: 10px;

--- a/src/pages/Layout/Navbar.js
+++ b/src/pages/Layout/Navbar.js
@@ -4,7 +4,6 @@ import { Link } from "react-router-dom";
 import ExpandedMenu from "../Auxiliary/ExpandedMenu";
 
 export default function Navbar() {
-  const [clicked, setClicked] = useState(false);
   const [isMenuExpanded, setExpandMenu] = useState(false);
   let ACTIVE = "active";
   let menuRef = useRef();
@@ -85,15 +84,9 @@ export default function Navbar() {
             </div>
           </div>
         </div>
-        <div id="logo-container">
-          <Link to="/">
-            <img
-              src={`${process.env.PUBLIC_URL}/images/The Independence Logo.png`}
-              alt="The Independence Logo"
-            />
-          </Link>
-        </div>
-
+        <Link className="independence-header" to="/">
+          <h4>The Independence</h4>
+        </Link>
         <div>
           <ul id="navbar">
             <li>

--- a/src/pages/Layout/ThinNavbar.js
+++ b/src/pages/Layout/ThinNavbar.js
@@ -100,7 +100,7 @@ export default function ThinNavbar() {
           </div>
         </div>
 
-        <Link id="independence-header" to="/">
+        <Link className="independence-header" to="/">
           <h4>The Independence</h4>
         </Link>
 

--- a/src/pages/Layout/assets/ThinNavbar.css
+++ b/src/pages/Layout/assets/ThinNavbar.css
@@ -3,25 +3,12 @@
   display: grid;
   width: 100vw;
   height: 100vh;
-  height: var(--nav-bar-height-thin);
+  height: var(--nav-bar-height);
   top: 0;
   z-index: 5;
   grid-template-columns: repeat(3, 1fr);
   padding-top: 5px;
   color: white;
-}
-
-#independence-header {
-  justify-self: center;
-  font-size: 2.2rem;
-  font-weight: 400;
-  font-family: Times, Georgia, serif;
-  color: white;
-  text-decoration: none;
-}
-
-#independence-header h4 {
-  font-weight: 200;
 }
 
 #thin-navbar-wrapper #expand-menu {
@@ -50,20 +37,10 @@
   #thin-navbar {
     display: none;
   }
-
-  #independence-header {
-    grid-column: 2 / 4;
-    justify-self: start;
-  }
 }
 
 @media screen and (max-width: 425px) {
   #thin-navbar-wrapper {
     grid-template-columns: 0.5fr 1fr 1fr;
-  }
-
-  #independence-header * {
-    font-size: 1.5rem;
-    padding-left: 20px;
   }
 }


### PR DESCRIPTION
# Purpose

Trim the height of the `Navbar`

## Implementation details

This involved removing the logo from `Navbar`, and reducing the component's max height. This partially implements #35, and closes #36.